### PR TITLE
Migrate from AWS Java SDK v1 to v2 and KPL 1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- KPL 1.x generated protobuf code requires protobuf-java 4.x.
+           Pin here so it wins over the 3.x dragged in by google-cloud-bigquerystorage. -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>4.29.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -323,7 +330,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
     </dependency>
     <dependency>
       <groupId>redis.clients</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mockito.version>5.19.0</mockito.version>
     <opencensus.version>0.28.3</opencensus.version>
-    <aws-java.version>1.12.782</aws-java.version>
+    <aws-sdk-v2.version>2.34.0</aws-sdk-v2.version>
+    <kpl.version>1.0.7</kpl.version>
     <jackson.version>2.15.2</jackson.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -154,6 +155,18 @@
     </profile>
   </profiles>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${aws-sdk-v2.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <!-- very important deps -->
     <dependency>
@@ -165,11 +178,6 @@
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
       <version>0.9.5.5</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.782</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -276,29 +284,21 @@
       <version>2.49.0</version>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.12.782</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sns</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sns</artifactId>
-      <version>${aws-java.version}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sqs</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sqs</artifactId>
-      <version>${aws-java.version}</version>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
-      <version>${aws-java.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
+      <groupId>software.amazon.kinesis</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
-      <version>0.15.12</version>
+      <version>${kpl.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/src/main/java/com/zendesk/maxwell/filtering/FilterParser.java
+++ b/src/main/java/com/zendesk/maxwell/filtering/FilterParser.java
@@ -1,11 +1,10 @@
 package com.zendesk.maxwell.filtering;
 
-import com.amazonaws.util.StringInputStream;
-
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StreamTokenizer;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -22,11 +21,7 @@ public class FilterParser {
 	}
 
 	public List<FilterPattern> parse() throws InvalidFilterException {
-		try {
-			this.inputStream = new InputStreamReader(new StringInputStream(input));
-		} catch ( UnsupportedEncodingException e ) {
-			throw new InvalidFilterException(e.getMessage());
-		}
+		this.inputStream = new InputStreamReader(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
 
 		this.tokenizer = new StreamTokenizer(inputStream);
 		try {

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellKinesisProducer.java
@@ -18,11 +18,11 @@ import com.zendesk.maxwell.producer.partitioners.MaxwellKinesisPartitioner;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
 
-import com.amazonaws.services.kinesis.producer.Attempt;
-import com.amazonaws.services.kinesis.producer.KinesisProducer;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
-import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
-import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import software.amazon.kinesis.producer.Attempt;
+import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.KinesisProducerConfiguration;
+import software.amazon.kinesis.producer.UserRecordFailedException;
+import software.amazon.kinesis.producer.UserRecordResult;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSNSProducer.java
@@ -1,31 +1,25 @@
 package com.zendesk.maxwell.producer;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.handlers.AsyncHandler;
-import com.amazonaws.services.sns.AmazonSNSAsync;
-import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
-import com.amazonaws.services.sns.model.MessageAttributeValue;
-import com.amazonaws.services.sns.model.PublishRequest;
-import com.amazonaws.services.sns.model.PublishResult;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.partitioners.MaxwellSNSPartitioner;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
-import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
 public class MaxwellSNSProducer extends AbstractAsyncProducer {
 
-	private AmazonSNSAsync client;
+	private SnsAsyncClient client;
 	private String topic;
-	private String[] stringFelds = {"database", "table"};
-	private String[] numberFields = {"ts", "xid"};
 	private MaxwellSNSPartitioner partitioner;
 
 	public MaxwellSNSProducer(MaxwellContext context, String topic, String serviceEndpoint, String signingRegion) {
@@ -35,12 +29,13 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 		// Only configure custom endpoint if both serviceEndpoint and signingRegion are provided
 		if (serviceEndpoint != null && !serviceEndpoint.trim().isEmpty() &&
 			signingRegion != null && !signingRegion.trim().isEmpty()) {
-			this.client = AmazonSNSAsyncClientBuilder.standard()
-					.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, signingRegion))
+			this.client = SnsAsyncClient.builder()
+					.endpointOverride(URI.create(serviceEndpoint))
+					.region(Region.of(signingRegion))
 					.build();
 		} else {
 			// Use default client configuration when endpoint parameters are not provided
-			this.client = AmazonSNSAsyncClientBuilder.defaultClient();
+			this.client = SnsAsyncClient.create();
 		}
 		String partitionKey = context.getConfig().producerPartitionKey;
 		String partitionColumns = context.getConfig().producerPartitionColumns;
@@ -48,17 +43,15 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 		this.partitioner = new MaxwellSNSPartitioner(partitionKey, partitionColumns, partitionFallback);
 	}
 
-	public void setClient(AmazonSNSAsync client) {
+	public void setClient(SnsAsyncClient client) {
 		this.client = client;
 	}
 
 	@Override
 	public void sendAsync(RowMap r, CallbackCompleter cc) throws Exception {
 		String value = r.toJSON(outputConfig);
-		// Publish a message to an Amazon SNS topic.
-		final PublishRequest publishRequest = new PublishRequest(topic, value);
-		Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
 
+		Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
 		final String configuredAttributes = context.getConfig().snsAttrs;
 		if (configuredAttributes != null) {
 			for (String element: configuredAttributes.split(",")) {
@@ -66,33 +59,39 @@ public class MaxwellSNSProducer extends AbstractAsyncProducer {
 					case "database":
 						messageAttributes.put(
 							"database",
-							new MessageAttributeValue().withDataType("String").withStringValue(r.getDatabase())
+							MessageAttributeValue.builder().dataType("String").stringValue(r.getDatabase()).build()
 						);
 						break;
 					case "table":
 						messageAttributes.put(
 							"table",
-							new MessageAttributeValue().withDataType("String").withStringValue(r.getTable())
+							MessageAttributeValue.builder().dataType("String").stringValue(r.getTable()).build()
 						);
 						break;
 				}
 			}
 		}
 
-		if ( topic.endsWith(".fifo")) {
+		PublishRequest.Builder builder = PublishRequest.builder()
+				.topicArn(topic)
+				.message(value)
+				.messageAttributes(messageAttributes);
+
+		if (topic.endsWith(".fifo")) {
 			String key = this.partitioner.getSNSKey(r);
-			publishRequest.setMessageGroupId(key);
+			builder.messageGroupId(key);
 		}
-		publishRequest.setMessageAttributes(messageAttributes);
+
+		PublishRequest publishRequest = builder.build();
 
 		SNSCallback callback = new SNSCallback(cc, r.getNextPosition(), value,
 			r.getDatabase(), r.getTable(), r.getRowIdentity().toConcatString(), r.getApproximateSize(), context);
-		client.publishAsync(publishRequest, callback);
+		client.publish(publishRequest).whenComplete(callback);
 	}
 
 }
 
-class SNSCallback implements AsyncHandler<PublishRequest, PublishResult> {
+class SNSCallback implements java.util.function.BiConsumer<PublishResponse, Throwable> {
 	public static final Logger logger = LoggerFactory.getLogger(SNSCallback.class);
 
 	private final AbstractAsyncProducer.CallbackCompleter cc;
@@ -118,23 +117,23 @@ class SNSCallback implements AsyncHandler<PublishRequest, PublishResult> {
 	}
 
 	@Override
-	public void onError(Exception t) {
-		logger.error(t.getClass().getSimpleName() + " @ " + position + " -- ");
-		logger.error("Database:" + database + ", Table:" + table + ", PK:" + pk + ", Approx Size:" + Long.toString(approximateRowSize));
-		logger.error(t.getLocalizedMessage());
-		logger.error("Exception during put", t);
+	public void accept(PublishResponse response, Throwable t) {
+		if (t != null) {
+			logger.error(t.getClass().getSimpleName() + " @ " + position + " -- ");
+			logger.error("Database:" + database + ", Table:" + table + ", PK:" + pk + ", Approx Size:" + Long.toString(approximateRowSize));
+			logger.error(t.getLocalizedMessage());
+			logger.error("Exception during put", t);
 
-		if (!context.getConfig().ignoreProducerError) {
-			context.terminate(new RuntimeException(t));
-		} else {
-			cc.markCompleted();
+			if (!context.getConfig().ignoreProducerError) {
+				context.terminate(new RuntimeException(t));
+			} else {
+				cc.markCompleted();
+			}
+			return;
 		}
-	};
 
-	@Override
-	public void onSuccess(PublishRequest request, PublishResult result) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("-> MessageId: {}", result.getMessageId());
+			logger.debug("-> MessageId: {}", response.messageId());
 		}
 		cc.markCompleted();
 	}

--- a/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
+++ b/src/main/java/com/zendesk/maxwell/producer/MaxwellSQSProducer.java
@@ -1,30 +1,30 @@
 package com.zendesk.maxwell.producer;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.amazonaws.handlers.AsyncHandler;
-import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
-import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.producer.partitioners.MaxwellSQSPartitioner;
 import com.zendesk.maxwell.replication.Position;
 import com.zendesk.maxwell.row.RowMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+import java.net.URI;
 
 public class MaxwellSQSProducer extends AbstractAsyncProducer {
 
-	private AmazonSQSAsync client;
+	private SqsAsyncClient client;
 	private String queueUri;
 	private MaxwellSQSPartitioner partitioner;
 
 	public MaxwellSQSProducer(MaxwellContext context, String queueUri, String serviceEndpoint, String signingRegion) {
 		super(context);
 		this.queueUri = queueUri;
-		this.client = AmazonSQSAsyncClientBuilder.standard()
-				.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, signingRegion))
+		this.client = SqsAsyncClient.builder()
+				.endpointOverride(URI.create(serviceEndpoint))
+				.region(Region.of(signingRegion))
 				.build();
 		String partitionKey = context.getConfig().producerPartitionKey;
 		String partitionColumns = context.getConfig().producerPartitionColumns;
@@ -35,18 +35,24 @@ public class MaxwellSQSProducer extends AbstractAsyncProducer {
 	@Override
 	public void sendAsync(RowMap r, CallbackCompleter cc) throws Exception {
 		String value = r.toJSON(outputConfig);
-		SendMessageRequest messageRequest = new SendMessageRequest(queueUri, value);
-		if ( queueUri.endsWith(".fifo")) {
+
+		SendMessageRequest.Builder builder = SendMessageRequest.builder()
+				.queueUrl(queueUri)
+				.messageBody(value);
+
+		if (queueUri.endsWith(".fifo")) {
 			String key = this.partitioner.getSQSKey(r);
-			messageRequest.setMessageGroupId(key);
+			builder.messageGroupId(key);
 		}
+
+		SendMessageRequest messageRequest = builder.build();
 		SQSCallback callback = new SQSCallback(cc, r.getNextPosition(), value, context);
-		client.sendMessageAsync(messageRequest, callback);
+		client.sendMessage(messageRequest).whenComplete(callback);
 	}
 
 }
 
-class SQSCallback implements AsyncHandler<SendMessageRequest, SendMessageResult> {
+class SQSCallback implements java.util.function.BiConsumer<SendMessageResponse, Throwable> {
 	public static final Logger logger = LoggerFactory.getLogger(SQSCallback.class);
 
 	private final AbstractAsyncProducer.CallbackCompleter cc;
@@ -63,23 +69,23 @@ class SQSCallback implements AsyncHandler<SendMessageRequest, SendMessageResult>
 	}
 
 	@Override
-	public void onError(Exception t) {
-		logger.error(t.getClass().getSimpleName() + " @ " + position + " -- ");
-		logger.error(t.getLocalizedMessage());
-		logger.error("Exception during put", t);
+	public void accept(SendMessageResponse response, Throwable t) {
+		if (t != null) {
+			logger.error(t.getClass().getSimpleName() + " @ " + position + " -- ");
+			logger.error(t.getLocalizedMessage());
+			logger.error("Exception during put", t);
 
-		if (!context.getConfig().ignoreProducerError) {
-			context.terminate(new RuntimeException(t));
-		} else {
-			cc.markCompleted();
+			if (!context.getConfig().ignoreProducerError) {
+				context.terminate(new RuntimeException(t));
+			} else {
+				cc.markCompleted();
+			}
+			return;
 		}
-	};
 
-	@Override
-	public void onSuccess(SendMessageRequest request, SendMessageResult result) {
 		if (logger.isDebugEnabled()) {
 			logger.debug("-> Message id:{}, sequence number:{}  {}  {}",
-					result.getMessageId(), result.getSequenceNumber(), json, position);
+					response.messageId(), response.sequenceNumber(), json, position);
 		}
 		cc.markCompleted();
 	}

--- a/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/KinesisCallbackTest.java
@@ -2,7 +2,7 @@ package com.zendesk.maxwell.producer;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
-import com.amazonaws.services.kinesis.producer.IrrecoverableError;
+import software.amazon.kinesis.producer.IrrecoverableError;
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.replication.BinlogPosition;

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellSNSProducerTest.java
@@ -1,12 +1,5 @@
 package com.zendesk.maxwell.producer;
 
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.AmazonSNSAsync;
-import com.amazonaws.services.sns.AmazonSNSAsyncClient;
-import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
-import com.amazonaws.services.sns.model.MessageAttributeValue;
-import com.amazonaws.services.sns.model.PublishRequest;
-import com.amazonaws.services.sns.model.PublishResult;
 import com.zendesk.maxwell.MaxwellConfig;
 import com.zendesk.maxwell.MaxwellContext;
 import com.zendesk.maxwell.monitoring.NoOpMetrics;
@@ -22,21 +15,29 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.services.sns.SnsAsyncClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
 
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.*;
+
 public class MaxwellSNSProducerTest {
 
 	private static final long TIMESTAMP_MILLISECONDS = 1496712943447L;
 	private static final String TOPIC = "topic";
 	private static final String FIFO_TOPIC = "topic.fifo";
 	private static final Position POSITION = new Position(new BinlogPosition(1L, "binlog-0001"), 0L);
-	private static final Future<PublishResult> mockedFuture = Mockito.mock(Future.class);
+	private static final CompletableFuture<PublishResponse> mockedFuture =
+			CompletableFuture.completedFuture(PublishResponse.builder().messageId("mid").build());
+
 	@Rule
 	public final EnvironmentVariables environmentVariables
 			= new EnvironmentVariables();
@@ -55,7 +56,7 @@ public class MaxwellSNSProducerTest {
 
 	@Test
 	public void publishesRecord() throws Exception {
-		AmazonSNSAsyncClient client = Mockito.mock(AmazonSNSAsyncClient.class);
+		SnsAsyncClient client = Mockito.mock(SnsAsyncClient.class);
 		MaxwellContext context = mock(MaxwellContext.class);
 		when(context.getConfig()).thenReturn(new MaxwellConfig());
 		when(context.getMetrics()).thenReturn(new NoOpMetrics());
@@ -63,16 +64,16 @@ public class MaxwellSNSProducerTest {
 		producer.setClient(client);
 		String payload = rowMap.toJSON();
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
-		when(client.publishAsync(any())).thenReturn(mockedFuture);
+		when(client.publish(any(PublishRequest.class))).thenReturn(mockedFuture);
 		producer.sendAsync(rowMap, cc);
-		Mockito.verify(client, times(1)).publishAsync(arguments.capture(), any());
-		Assert.assertEquals(arguments.getValue().getTopicArn(), TOPIC);
-		Assert.assertEquals(arguments.getValue().getMessage(), payload);
+		Mockito.verify(client, times(1)).publish(arguments.capture());
+		Assert.assertEquals(arguments.getValue().topicArn(), TOPIC);
+		Assert.assertEquals(arguments.getValue().message(), payload);
 	}
 
 	@Test
 	public void setsMessageAttributes() throws Exception {
-		AmazonSNSAsyncClient client = Mockito.mock(AmazonSNSAsyncClient.class);
+		SnsAsyncClient client = Mockito.mock(SnsAsyncClient.class);
 		MaxwellContext context = mock(MaxwellContext.class);
 		MaxwellConfig config = new MaxwellConfig();
 		config.snsAttrs = "database,table";
@@ -81,29 +82,28 @@ public class MaxwellSNSProducerTest {
 		MaxwellSNSProducer producer = new MaxwellSNSProducer(context, TOPIC, "", "");
 		producer.setClient(client);
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
-		when(client.publishAsync(any())).thenReturn(mockedFuture);
+		when(client.publish(any(PublishRequest.class))).thenReturn(mockedFuture);
 		producer.sendAsync(rowMap, cc);
-		Mockito.verify(client, times(1)).publishAsync(arguments.capture(), any());
-		Map<String, MessageAttributeValue> attributes = arguments.getValue().getMessageAttributes();
+		Mockito.verify(client, times(1)).publish(arguments.capture());
+		Map<String, MessageAttributeValue> attributes = arguments.getValue().messageAttributes();
 		Assert.assertNotNull(attributes.getOrDefault("table", null));
-		Assert.assertEquals("MyTable", attributes.get("table").getStringValue());
+		Assert.assertEquals("MyTable", attributes.get("table").stringValue());
 		Assert.assertNotNull(attributes.getOrDefault("database", null));
-		Assert.assertEquals("MyDatabase", attributes.get("database").getStringValue());
+		Assert.assertEquals("MyDatabase", attributes.get("database").stringValue());
 	}
 
 	@Test
 	public void ensureMessageGroupIdOnFifo() throws Exception {
-		AmazonSNSAsyncClient client = Mockito.mock(AmazonSNSAsyncClient.class);
+		SnsAsyncClient client = Mockito.mock(SnsAsyncClient.class);
 		MaxwellContext context = mock(MaxwellContext.class);
 		when(context.getConfig()).thenReturn(new MaxwellConfig());
 		when(context.getMetrics()).thenReturn(new NoOpMetrics());
 		MaxwellSNSProducer producer = new MaxwellSNSProducer(context, FIFO_TOPIC, "", "");
 		producer.setClient(client);
 		AbstractAsyncProducer.CallbackCompleter cc = mock(AbstractAsyncProducer.CallbackCompleter.class);
-		when(client.publishAsync(any())).thenReturn(mockedFuture);
+		when(client.publish(any(PublishRequest.class))).thenReturn(mockedFuture);
 		producer.sendAsync(rowMap, cc);
-		Mockito.verify(client, times(1)).publishAsync(arguments.capture(), any());
-		Map<String, MessageAttributeValue> attributes = arguments.getValue().getMessageAttributes();
-		Assert.assertEquals("MyDatabase", arguments.getValue().getMessageGroupId());
+		Mockito.verify(client, times(1)).publish(arguments.capture());
+		Assert.assertEquals("MyDatabase", arguments.getValue().messageGroupId());
 	}
 }


### PR DESCRIPTION
## Summary

- AWS Java SDK 1.x reached end of support on Dec 31, 2025; AWS Enterprise Support is paging the affected Mavenlink/Kantata accounts every ~16 days until usage stops. This PR removes Maxwell's usage of the `com.amazonaws.*` namespace.
- SNS and SQS producers ported to SDK v2 (`SnsAsyncClient` / `SqsAsyncClient`) with `CompletableFuture.whenComplete()` replacing the v1 `AsyncHandler` callbacks. FIFO `messageGroupId`, message attributes, and `ignoreProducerError` semantics preserved.
- Kinesis producer moves from `com.amazonaws:amazon-kinesis-producer:0.15.12` to `software.amazon.kinesis:amazon-kinesis-producer:1.0.7` — KPL 1.x is internally on SDK v2 and the public Java API is source-compatible; the change is an import rename.
- `FilterParser`'s stray `com.amazonaws.util.StringInputStream` replaced with `ByteArrayInputStream` (UTF-8).
- `pom.xml`: replaced `aws-java-sdk-{core,sns,sqs,sts}@1.12.782` with the v2 BOM at `2.34.0` (sns/sqs/sts), removed a duplicate `aws-java-sdk-core` entry.

Behavior, CLI flags, config properties, and credential chain are unchanged. SDK v2's `DefaultCredentialsProvider` covers the same sources (env, sys-props, IRSA via STS, profile, IMDS) as v1's chain.

## Test plan

- [x] `grep -r com.amazonaws src/ pom.xml` returns nothing
- [x] `mvn dependency:tree | grep com.amazonaws` returns nothing (zero v1 artifacts remain transitively)
- [x] `mvn -DskipTests package` builds cleanly
- [x] `mvn -Dtest=MaxwellSNSProducerTest,KinesisCallbackTest test` — 5/5 pass
- [x] `mvn -Dtest=FilterTest test` — 16/16 pass (exercises the FilterParser change)
- [x] End-to-end LocalStack smoke: MySQL 8 (ROW binlog + GTID) → Maxwell `--producer=sqs` → LocalStack SQS. Insert/update/delete on a test table; all 4 events arrive in the queue with correct payloads (including `old` values on update). SDK v2 builder + endpoint override + credential chain code path verified end-to-end against a real SQS-compatible endpoint.
- [ ] Verify SNS end-to-end against a real or LocalStack-Pro SNS topic (skipped — SQS smoke exercises the same SDK v2 builder/endpoint/credential code path)
- [ ] Verify Kinesis end-to-end against a real Kinesis stream (skipped — KPL change is an import-only rename and the unit test covers callback behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)